### PR TITLE
feat: Hide prediction game when there is no active season

### DIFF
--- a/src/components/PredictionGame.tsx
+++ b/src/components/PredictionGame.tsx
@@ -46,9 +46,12 @@ export const PredictionGame: FC<PredictionGameProps> = ({ assignments, searchQue
 	const { data: session } = api.auth.getSession.useQuery();
 	const { data: hosts } = api.user.hosts.useQuery();
 	const { data: ratings } = api.movie.ratings.useQuery();
+	const { data: hasActiveSeason } = api.season.hasActiveSeason.useQuery();
 	const [isAdminCollapsed, setIsAdminCollapsed] = useState(true);
 	const flagEnabled = useFeatureFlagEnabled('new-season-format')
 
+	if (hasActiveSeason === false) return null;
+	if (hasActiveSeason === undefined) return <div className="p-4 text-center text-gray-400">Checking season status...</div>;
 	if (!session?.user) return <div className="p-4 text-center text-gray-400">Please <SignInButton /> to play the game.</div>;
 	if (!hosts || !ratings) return <div className="p-4 text-center text-gray-400">Loading prediction game...</div>;
 	const isAdmin = session.user.isAdmin;

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -14,6 +14,7 @@ import { reviewRouter } from "./routers/reviewRouter";
 import { adminRouter } from "./routers/adminRouter";
 import { videoRouter } from "./routers/videoRouter";
 import { featureRouter } from "./routers/featureRouter";
+import { seasonRouter } from "./routers/seasonRouter";
 
 export const appRouter = createTRPCRouter({
 	year: yearRouter,
@@ -31,6 +32,7 @@ export const appRouter = createTRPCRouter({
 	feature: featureRouter,
 	syllabus: syllabusRouter,
 	show: showRouter,
+	season: seasonRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/api/routers/seasonRouter.ts
+++ b/src/server/api/routers/seasonRouter.ts
@@ -1,0 +1,9 @@
+import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
+import { getCurrentSeasonID } from "@/utils/points";
+
+export const seasonRouter = createTRPCRouter({
+    hasActiveSeason: publicProcedure.query(async ({ ctx }) => {
+        const seasonId = await getCurrentSeasonID(ctx.db);
+        return seasonId !== null;
+    }),
+});


### PR DESCRIPTION
This commit adds a new `seasonRouter` with a `hasActiveSeason` tRPC query. The `PredictionGame` component now uses this query to check if there is an active season, and if not, it returns `null` to hide the prediction game on the Episode component.

---
*PR created automatically by Jules for task [8809501668084128564](https://jules.google.com/task/8809501668084128564) started by @tonyisup*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added season status checking to the prediction game; displays "Checking season status..." while loading.
  * Game no longer renders when no active season exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->