### PR TITLE
feat: Migrate Season date columns to SQL Server DATE type

### DIFF
--- a/docs/season-date-migration.md
+++ b/docs/season-date-migration.md
@@ -1,0 +1,12 @@
+# Season date column migration
+
+The Prisma schema now models `Season.startedOn` and `Season.endedOn` as SQL Server `DATE` columns.
+
+Apply [`../prisma/manual-migrations/20260317_season_date_columns.sql`](../prisma/manual-migrations/20260317_season_date_columns.sql) during deployment before rolling out code that depends on the new schema shape.
+
+Deployment notes:
+
+- The script creates a one-time backup table named `dbo.Season_backup_20260317` before modifying `dbo.Season`.
+- Existing `DATETIME` values are truncated to their calendar date with `CAST(... AS DATE)`. Any time-of-day component is intentionally discarded.
+- The migration is wrapped in a transaction and is a no-op when the columns are already `DATE`.
+- Rollback should restore the saved rows from `dbo.Season_backup_20260317` into `dbo.Season` if you need to recover the original timestamps.

--- a/prisma/manual-migrations/20260317_season_date_columns.sql
+++ b/prisma/manual-migrations/20260317_season_date_columns.sql
@@ -3,7 +3,15 @@ IF EXISTS (
   FROM INFORMATION_SCHEMA.COLUMNS
   WHERE TABLE_SCHEMA = 'dbo'
     AND TABLE_NAME = 'Season'
-    AND COLUMN_NAME IN ('startedOn', 'endedOn')
+    AND COLUMN_NAME = 'startedOn'
+    AND DATA_TYPE <> 'date'
+)
+OR EXISTS (
+  SELECT 1
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = 'dbo'
+    AND TABLE_NAME = 'Season'
+    AND COLUMN_NAME = 'endedOn'
     AND DATA_TYPE <> 'date'
 )
 BEGIN
@@ -17,19 +25,43 @@ BEGIN
       FROM dbo.Season;
     END;
 
-    ALTER TABLE dbo.Season
-      ADD startedOn_date DATE NULL,
-          endedOn_date DATE NULL;
+    IF EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = 'dbo'
+        AND TABLE_NAME = 'Season'
+        AND COLUMN_NAME = 'startedOn'
+        AND DATA_TYPE <> 'date'
+    )
+    BEGIN
+      ALTER TABLE dbo.Season ADD startedOn_date DATE NULL;
 
-    UPDATE dbo.Season
-    SET startedOn_date = CAST(startedOn AS DATE),
-        endedOn_date = CAST(endedOn AS DATE);
+      UPDATE dbo.Season
+      SET startedOn_date = CAST(startedOn AS DATE);
 
-    ALTER TABLE dbo.Season DROP COLUMN startedOn;
-    ALTER TABLE dbo.Season DROP COLUMN endedOn;
+      ALTER TABLE dbo.Season DROP COLUMN startedOn;
 
-    EXEC sp_rename 'dbo.Season.startedOn_date', 'startedOn', 'COLUMN';
-    EXEC sp_rename 'dbo.Season.endedOn_date', 'endedOn', 'COLUMN';
+      EXEC sp_rename 'dbo.Season.startedOn_date', 'startedOn', 'COLUMN';
+    END;
+
+    IF EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = 'dbo'
+        AND TABLE_NAME = 'Season'
+        AND COLUMN_NAME = 'endedOn'
+        AND DATA_TYPE <> 'date'
+    )
+    BEGIN
+      ALTER TABLE dbo.Season ADD endedOn_date DATE NULL;
+
+      UPDATE dbo.Season
+      SET endedOn_date = CAST(endedOn AS DATE);
+
+      ALTER TABLE dbo.Season DROP COLUMN endedOn;
+
+      EXEC sp_rename 'dbo.Season.endedOn_date', 'endedOn', 'COLUMN';
+    END;
 
     COMMIT TRANSACTION;
   END TRY

--- a/scripts/backfill_slugs.mjs
+++ b/scripts/backfill_slugs.mjs
@@ -37,12 +37,13 @@ function buildEpisodeSlugBase(episode) {
 }
 
 function buildAssignmentSlugBase(assignment) {
+  const episodeLabel = assignment.episode?.number ?? "episode";
   const userLabel =
     assignment.user.name?.trim() || `user-${assignment.userId.slice(0, 8)}`;
   const movieLabel = assignment.movie.title?.trim() || "assignment";
 
   return slugify(
-    `episode-${assignment.episode.number}-${userLabel}-${movieLabel}-${
+    `episode-${episodeLabel}-${userLabel}-${movieLabel}-${
       assignmentTypeLabels[assignment.type]
     }`
   );

--- a/src/components/Episode.tsx
+++ b/src/components/Episode.tsx
@@ -2,7 +2,9 @@ import { type FC } from "react";
 import Assignment from "./Assignment";
 import MovieInlinePreview from "./MovieInlinePreview";
 import type {
+  AssignmentReview,
   Assignment as PrismaAssignment,
+  GamblingPoints,
   Link as EpisodeLink,
   Movie,
   Show,
@@ -25,8 +27,8 @@ import { formatPlainDate } from "@/lib/dates";
 type EpisodeAssignment = PrismaAssignment & {
   movie: Movie | null;
   user: User;
-  assignmentReviews?: any[];
-  gamblingPoints?: any[];
+  assignmentReviews?: AssignmentReview[];
+  gamblingPoints?: GamblingPoints[];
 };
 export type EpisodeExtra = {
   id: string;
@@ -88,7 +90,7 @@ export const Episode: FC<EpisodeProps> = ({
   searchQuery = "",
 }) => {
   if (!episode) return null;
-  if (isNextEpisode == null) isNextEpisode = false;
+  const showPredictionGame = isNextEpisode ?? false;
   const predictionAssignments = episode.assignments
     .map(mapEpisodeToPredictionAssignment)
     .filter(
@@ -140,7 +142,7 @@ export const Episode: FC<EpisodeProps> = ({
           showMovieTitles={showMovieTitles}
           searchQuery={searchQuery}
         />
-        {isNextEpisode && predictionAssignments.length > 0 && (
+        {showPredictionGame && predictionAssignments.length > 0 && (
           <PredictionGame
             assignments={predictionAssignments}
             searchQuery={searchQuery}
@@ -160,7 +162,7 @@ export const Episode: FC<EpisodeProps> = ({
             />
           </>
         )}
-        {isNextEpisode && <AddExtraToNext episode={episode} />}
+        {showPredictionGame && <AddExtraToNext episode={episode} />}
         <EpisodeLinks links={episode.links} />
       </div>
     </section>
@@ -204,7 +206,6 @@ const EpisodeAssignments: FC<EpisodeAssignments> = ({
             >
               <Assignment
                 assignment={assignment}
-                key={assignment.id}
                 showMovieTitles={showMovieTitles}
                 searchQuery={searchQuery}
               />
@@ -235,7 +236,7 @@ const EpisodeExtras: FC<EpisodeExtras> = ({
 }) => {
   if (!extras || extras.length == 0) return null;
   return (
-    <div className="py-2t">
+    <div className="py-2">
       <div className="flex flex-wrap justify-center gap-2 pb-2">
         {extras.map((extra) => {
           const extraTitle = extra.review.movie

--- a/src/components/PredictionGame.tsx
+++ b/src/components/PredictionGame.tsx
@@ -34,6 +34,13 @@ export type PredictionGameAssignment = {
     title: string;
   } | null;
 };
+
+const getGuessReviewUserId = (guess: any) =>
+  guess.assignmentReview?.review?.userId ??
+  guess.assignmentReview?.review?.user?.id ??
+  guess.AssignmentReview?.Review?.userId ??
+  guess.AssignmentReview?.Review?.User?.id ??
+  null;
 /**
  * Props for the PredictionGame component.
  */
@@ -85,6 +92,10 @@ export const PredictionGame: FC<PredictionGameProps> = ({
       </div>
     );
   const isAdmin = session.user.isAdmin;
+  const toggleAdminCollapse = () => {
+    if (!isAdmin) return;
+    setIsAdminCollapsed((value) => !value);
+  };
 
   return (
     <div className="mt-6 flex flex-col gap-6 rounded-xl border border-gray-700 bg-gray-900/50 p-4 shadow-xl backdrop-blur-sm sm:gap-8 sm:p-6">
@@ -93,7 +104,16 @@ export const PredictionGame: FC<PredictionGameProps> = ({
           "flex flex-col gap-2 pb-4",
           isAdmin ? "cursor-pointer select-none" : "border-b border-gray-700"
         )}
-        onClick={() => isAdmin && setIsAdminCollapsed(!isAdminCollapsed)}
+        role="button"
+        tabIndex={isAdmin ? 0 : -1}
+        onClick={toggleAdminCollapse}
+        onKeyDown={(event) => {
+          if (!isAdmin) return;
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            toggleAdminCollapse();
+          }
+        }}
       >
         <div className="flex items-center justify-between">
           <div className="flex flex-col gap-1">
@@ -265,6 +285,7 @@ const AssignmentPrediction: FC<AssignmentPredictionProps> = ({
     (acc: number, p: any) => acc + p.points,
     0
   );
+  const expandAssignment = () => setUserExpanded(true);
 
   const submitGuess = api.review.submitGuess.useMutation({
     onMutate: async (newGuess) => {
@@ -281,11 +302,9 @@ const AssignmentPrediction: FC<AssignmentPredictionProps> = ({
         { assignmentIds: [assignment.id], userId },
         (old) => {
           const oldGuesses = old?.[assignment.id] ?? [];
-          const filtered = oldGuesses.filter((g: any) => {
-            const reviewUserId = g.AssignmentReview?.Review?.userId;
-            const reviewUserObjId = g.AssignmentReview?.Review?.User?.id;
-            return (reviewUserId ?? reviewUserObjId) !== newGuess.hostId;
-          });
+          const filtered = oldGuesses.filter(
+            (guess: any) => getGuessReviewUserId(guess) !== newGuess.hostId
+          );
 
           const rating = ratings.find((r) => r.id === newGuess.ratingId);
           if (!rating) return old;
@@ -346,11 +365,7 @@ const AssignmentPrediction: FC<AssignmentPredictionProps> = ({
   const getGuessForHost = (hostId: string) => {
     if (!guesses) return null;
 
-    return guesses.find((g: any) => {
-      const reviewUserId = g.assignmentReview?.review?.userId;
-      const reviewUserObjId = g.assignmentReview?.review?.user?.id;
-      return (reviewUserId ?? reviewUserObjId) === hostId;
-    });
+    return guesses.find((guess: any) => getGuessReviewUserId(guess) === hostId);
   };
 
   /* These are pre-fetched */
@@ -365,7 +380,19 @@ const AssignmentPrediction: FC<AssignmentPredictionProps> = ({
       {isCollapsed ? (
         <div
           className="flex cursor-pointer items-center gap-2 rounded-lg border border-gray-700/50 bg-gray-800/40 p-2 transition-colors hover:bg-gray-800/60 sm:gap-4 sm:p-3"
-          onClick={() => setUserExpanded(true)}
+          role="button"
+          tabIndex={0}
+          aria-expanded={!isCollapsed}
+          aria-label={`Expand predictions for ${
+            assignment.movie?.title ?? "this assignment"
+          }`}
+          onClick={expandAssignment}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              expandAssignment();
+            }
+          }}
         >
           <span className="sm:text-md flex-grow pr-2 text-lg font-bold text-white">
             {assignment.movie
@@ -392,14 +419,14 @@ const AssignmentPrediction: FC<AssignmentPredictionProps> = ({
             {gambleAmountForAssignment > 0 && (
               <div className="flex items-center whitespace-nowrap rounded border border-purple-500/30 bg-purple-900/50 px-1.5 py-0.5 text-[10px] font-bold text-purple-200 sm:px-2 sm:py-1 sm:text-sm">
                 {gambleAmountForAssignment}{" "}
-                <Coins className="h-3 h-5 w-3 pl-0.5 sm:w-5 sm:pl-1" />
+                <Coins className="h-3 w-3 pl-0.5 sm:h-5 sm:w-5 sm:pl-1" />
               </div>
             )}
 
             <Message assignmentId={assignment.id} userId={userId}>
               <div className="flex items-center whitespace-nowrap rounded border border-green-500/30 bg-green-900/50 px-1.5 py-0.5 text-[10px] font-bold text-green-200 sm:px-2 sm:py-1 sm:text-sm">
                 {audioMessageCount ?? 0}{" "}
-                <Voicemail className="h-3 h-5 w-3 pl-0.5 sm:w-5 sm:pl-1" />
+                <Voicemail className="h-3 w-3 pl-0.5 sm:h-5 sm:w-5 sm:pl-1" />
               </div>
             </Message>
 
@@ -417,6 +444,7 @@ const AssignmentPrediction: FC<AssignmentPredictionProps> = ({
             </h3>
             {hasAllGuesses && (
               <button
+                type="button"
                 onClick={() => setUserExpanded(false)}
                 className="rounded p-1 text-gray-400 transition-colors hover:bg-gray-800 hover:text-white"
               >

--- a/src/server/api/routers/yearRouter.ts
+++ b/src/server/api/routers/yearRouter.ts
@@ -6,8 +6,8 @@ export const yearRouter = createTRPCRouter({
   getMyYearData: publicProcedure
     .input(z.object({ year: z.number() }))
     .query(async ({ ctx, input }) => {
-      const yearStart = new Date(input.year, 0, 1);
-      const yearEnd = new Date(input.year + 1, 0, 1);
+      const yearStart = new Date(Date.UTC(input.year, 0, 1));
+      const yearEnd = new Date(Date.UTC(input.year + 1, 0, 1));
       const isAdmin = ctx.session?.user?.isAdmin;
 
       const whereClause: {
@@ -24,7 +24,7 @@ export const yearRouter = createTRPCRouter({
         },
       };
 
-      if (isAdmin) {
+      if (!isAdmin) {
         whereClause.userId = ctx.session?.user?.id;
       }
 


### PR DESCRIPTION
- Introduced a new migration script to change `startedOn` and `endedOn` columns in the Season model from DATETIME to DATE.
- Added documentation for the migration process, including backup and rollback procedures.
- Updated relevant components to accommodate the new date handling, ensuring consistency across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed admin user filtering logic in year-based queries
  * Improved slug generation to gracefully handle missing episode data

* **Improvements**
  * Enhanced accessibility in prediction game with keyboard navigation support and proper ARIA attributes
  * Strengthened type safety with improved type definitions
  * Refined UI interaction patterns for consistency

* **Documentation**
  * Added comprehensive database migration guide for season date column updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->