### PR TITLE
Fix bug allowing users to gamble with zero available points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+TODO.md
+CONVEX_SPIKE.md
 
 # dependencies
 /node_modules

--- a/src/components/AssignmentGamblingBoard.tsx
+++ b/src/components/AssignmentGamblingBoard.tsx
@@ -9,7 +9,6 @@ import RatingIcon from "./RatingIcon";
 
 interface AssignmentGamblingBoardProps {
 	assignmentId: string;
-	userId: string;
 	hosts: User[];
 	guesses: {
 		hostId: string;
@@ -25,7 +24,7 @@ const gamblingTitle = [
 	"You've got nothing to lose!",
 	"How confident are you?",
 ]
-const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentId, userId, hosts, guesses, episodeStatus }) => {
+const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentId, hosts, guesses, episodeStatus }) => {
 	const { data: gamblingTypes } = api.gambling.getAllActive.useQuery();
 	const { data: userPoints } = api.user.points.useQuery();
 	const { data: myBets, refetch: refetchBets } = api.gambling.getForAssignment.useQuery({ assignmentId });
@@ -103,7 +102,7 @@ const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentI
 							gamblingTypes={gamblingTypes}
 							getBetFor={getBetFor}
 							submitBet={submitBet}
-							userId={userId}
+
 							assignmentId={assignmentId}
 							userPoints={userPoints}
 							episodeStatus={episodeStatus}
@@ -143,7 +142,7 @@ const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentI
 						gamblingTypes={gamblingTypes}
 						getBetFor={getBetFor}
 						submitBet={submitBet}
-						userId={userId}
+
 						assignmentId={assignmentId}
 						userPoints={userPoints}
 						episodeStatus={episodeStatus}
@@ -160,7 +159,7 @@ const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentI
 						gamblingTypes={gamblingTypes}
 						getBetFor={getBetFor}
 						submitBet={submitBet}
-						userId={userId}
+
 						assignmentId={assignmentId}
 						userPoints={userPoints}
 						episodeStatus={episodeStatus}
@@ -175,7 +174,7 @@ const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentI
 						gamblingTypes={gamblingTypes}
 						getBetFor={getBetFor}
 						submitBet={submitBet}
-						userId={userId}
+
 						assignmentId={assignmentId}
 						userPoints={userPoints}
 						episodeStatus={episodeStatus}
@@ -190,7 +189,7 @@ const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentI
 						gamblingTypes={gamblingTypes}
 						getBetFor={getBetFor}
 						submitBet={submitBet}
-						userId={userId}
+
 						assignmentId={assignmentId}
 						userPoints={userPoints}
 						episodeStatus={episodeStatus}
@@ -210,7 +209,7 @@ const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentI
 							gamblingTypes={gamblingTypes}
 							getBetFor={getBetFor}
 							submitBet={submitBet}
-							userId={userId}
+
 							assignmentId={assignmentId}
 							userPoints={userPoints}
 							episodeStatus={episodeStatus}
@@ -228,7 +227,7 @@ const AssignmentGamblingBoard: FC<AssignmentGamblingBoardProps> = ({ assignmentI
 							gamblingTypes={gamblingTypes}
 							getBetFor={getBetFor}
 							submitBet={submitBet}
-							userId={userId}
+
 							assignmentId={assignmentId}
 							userPoints={userPoints}
 							episodeStatus={episodeStatus}

--- a/src/components/BettingCoin.tsx
+++ b/src/components/BettingCoin.tsx
@@ -42,6 +42,13 @@ const BettingCoin: FC<BettingCoinProps> = ({
 		if (!type) return;
 		const pts = parseInt(amount);
 		if (isNaN(pts)) return;
+		if (userPoints !== undefined) {
+			const currentBetAmount = existingBet ? existingBet.points : 0;
+			if (pts > userPoints + currentBetAmount) {
+				alert("Not enough points available to place this bet");
+				return;
+			}
+		}
 		submitBet.mutate({
 			userId,
 			gamblingTypeId: type.id,

--- a/src/components/BettingCoin.tsx
+++ b/src/components/BettingCoin.tsx
@@ -40,7 +40,10 @@ const BettingCoin: FC<BettingCoinProps> = ({
 		if (!type) return;
 		if (userPoints === undefined) return;
 		const pts = parseInt(amount);
-		if (isNaN(pts)) return;
+		if (isNaN(pts) || pts <= 0) {
+			alert("Please enter a valid amount greater than zero.");
+			return;
+		}
 
 		const currentBetAmount = existingBet ? existingBet.points : 0;
 		if (pts > userPoints + currentBetAmount) {

--- a/src/components/BettingCoin.tsx
+++ b/src/components/BettingCoin.tsx
@@ -15,7 +15,6 @@ export interface BettingCoinProps {
 	gamblingTypes: GamblingType[] | undefined;
 	getBetFor: (lookupId: string, targetHostId?: string) => GamblingPoints | undefined;
 	submitBet: any;
-	userId: string;
 	assignmentId: string;
 	userPoints: number | undefined;
 	episodeStatus: string;
@@ -28,7 +27,6 @@ const BettingCoin: FC<BettingCoinProps> = ({
 	gamblingTypes,
 	getBetFor,
 	submitBet,
-	userId,
 	assignmentId,
 	userPoints,
 	episodeStatus

--- a/src/components/BettingCoin.tsx
+++ b/src/components/BettingCoin.tsx
@@ -40,17 +40,17 @@ const BettingCoin: FC<BettingCoinProps> = ({
 
 	const handleBet = () => {
 		if (!type) return;
+		if (userPoints === undefined) return;
 		const pts = parseInt(amount);
 		if (isNaN(pts)) return;
-		if (userPoints !== undefined) {
-			const currentBetAmount = existingBet ? existingBet.points : 0;
-			if (pts > userPoints + currentBetAmount) {
-				alert("Not enough points available to place this bet");
-				return;
-			}
+
+		const currentBetAmount = existingBet ? existingBet.points : 0;
+		if (pts > userPoints + currentBetAmount) {
+			alert("Not enough points available to place this bet");
+			return;
 		}
+
 		submitBet.mutate({
-			userId,
 			gamblingTypeId: type.id,
 			points: pts,
 			assignmentId,
@@ -100,7 +100,7 @@ const BettingCoin: FC<BettingCoinProps> = ({
 						<Button
 							size="sm"
 							onClick={handleBet}
-							disabled={submitBet.isLoading || isLocked}
+							disabled={submitBet.isLoading || isLocked || userPoints === undefined}
 							className="h-8"
 						>
 							{submitBet.isLoading ? <Loader2 className="animate-spin w-3 h-3" /> : "Bet"}
@@ -112,9 +112,10 @@ const BettingCoin: FC<BettingCoinProps> = ({
 						</p>
 					)}
 					{!isLocked && existingBet?.status === "pending" && (
-						<Button variant="ghost" size="sm" onClick={() => {
+						<Button variant="ghost" size="sm" disabled={userPoints === undefined} onClick={() => {
+							if (userPoints === undefined) return;
 							setAmount("0");
-							submitBet.mutate({ userId, gamblingTypeId: type.id, points: 0, assignmentId, targetUserId: targetHostId });
+							submitBet.mutate({ gamblingTypeId: type.id, points: 0, assignmentId, targetUserId: targetHostId });
 						}} className="h-6 text-[10px] text-red-400 hover:text-red-300">
 							Clear Bet
 						</Button>

--- a/src/components/GamblingSection.tsx
+++ b/src/components/GamblingSection.tsx
@@ -36,6 +36,16 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, title }) =>
     { gamblingTypeId: gamblingTypeId }
   );
 
+  const currentEventBet = (eventGamblingPoints ?? [])
+    .filter((bet) => bet.status === "pending")
+    .sort((a, b) => {
+      const createdAtDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      if (createdAtDiff !== 0) return createdAtDiff;
+      return b.id.localeCompare(a.id);
+    })[0];
+
+  const currentBetAmount = Number(currentEventBet?.points ?? 0);
+
   const utils = api.useUtils();
 
   const { mutate: submitGamblingPoints } = api.gambling.submitPoints.useMutation({
@@ -60,7 +70,6 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, title }) =>
       return;
     }
 
-    const currentBetAmount = eventGamblingPoints?.[0]?.points ?? 0;
     if (gamblingPoints > Number(userPoints) + currentBetAmount) {
       alert("Not enough points available to place this bet");
       return;
@@ -74,15 +83,15 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, title }) =>
 
   useEffect(() => {
     const evalCanSubmitGamblingPoints = () => {
-      if (!userPoints) return false;
+      if (userPoints === undefined || userPoints === null) return false;
       if (Number(userPoints) <= 0) return false;
       if (isNaN(gamblingPoints) || gamblingPoints <= 0) return false;
-      if (gamblingPoints > Number(userPoints)) return false;
+      if (gamblingPoints > Number(userPoints) + currentBetAmount) return false;
       return true;
     }
 
     setCanSubmitGamblingPoints(evalCanSubmitGamblingPoints());
-  }, [userPoints, gamblingPoints]);
+  }, [userPoints, gamblingPoints, currentBetAmount]);
 
   const handleAutoBet = (amount: number) => {
     setGamblingPoints(amount);
@@ -91,14 +100,14 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, title }) =>
   if (userPoints === null || userPoints === undefined || Number(userPoints) < 0) return null;
 
   const hasGambled = () => {
-    return eventGamblingPoints && eventGamblingPoints.length > 0 && eventGamblingPoints[0] && eventGamblingPoints[0].points > 0;
+    return currentBetAmount > 0;
   }
   return (
     <div className="flex gap-2 items-center">
       <UserPoints points={Number(userPoints)} showSpendButton={false} />
       {hasGambled() && (
         <div className="flex gap-2 items-center">
-          <p className="text-sm text-gray-300">You have bet {eventGamblingPoints?.[0]?.points ?? "unknown"} points on {title}!</p>
+          <p className="text-sm text-gray-300">You have bet {currentBetAmount} points on {title}!</p>
           <Button
             variant="destructive"
             size="sm"

--- a/src/components/GamblingSection.tsx
+++ b/src/components/GamblingSection.tsx
@@ -55,6 +55,7 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, userId, tit
 
   const handleGamblingPointsSubmit = () => {
     if (!userId) return;
+    if (userPoints === undefined) return;
     if (gamblingPoints === undefined || gamblingPoints === null) return;
 
     if (isNaN(gamblingPoints) || gamblingPoints < 0) {
@@ -63,7 +64,6 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, userId, tit
     }
 
     submitGamblingPoints({
-      userId: userId,
       gamblingTypeId: gamblingTypeId,
       points: gamblingPoints
     });
@@ -103,7 +103,6 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, userId, tit
             onClick={() => {
               if (!userId) return;
               submitGamblingPoints({
-                userId: userId,
                 gamblingTypeId: gamblingTypeId,
                 points: 0
               });
@@ -135,7 +134,7 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, userId, tit
                 className="bg-gray-800 border-gray-700 text-white max-w-[100px]"
               />
               <Button
-                disabled={!canSubmitGamblingPoints}
+                disabled={!canSubmitGamblingPoints || userPoints === undefined}
                 className="text-gray-300 rounded-md bg-transparent hover:bg-red-800 border-[3px] border-red-800 hover:border-red-400 relative overflow-hidden group"
                 onClick={handleGamblingPointsSubmit}
               >

--- a/src/components/GamblingSection.tsx
+++ b/src/components/GamblingSection.tsx
@@ -55,8 +55,14 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, title }) =>
     if (userPoints === undefined) return;
     if (gamblingPoints === undefined || gamblingPoints === null) return;
 
-    if (isNaN(gamblingPoints) || gamblingPoints < 0) {
-      alert("Please enter a valid number of points");
+    if (isNaN(gamblingPoints) || gamblingPoints <= 0) {
+      alert("Please enter a valid number of points greater than zero.");
+      return;
+    }
+
+    const currentBetAmount = eventGamblingPoints?.[0]?.points ?? 0;
+    if (gamblingPoints > Number(userPoints) + currentBetAmount) {
+      alert("Not enough points available to place this bet");
       return;
     }
 

--- a/src/components/GamblingSection.tsx
+++ b/src/components/GamblingSection.tsx
@@ -16,8 +16,6 @@ import { cn } from "@/lib/utils";
 interface GamblingSectionProps {
   /** The unique identifier for the gambling type. */
   gamblingTypeId: string;
-  /** The unique identifier for the user placing the bet. */
-  userId: string;
   /** The title of the gambling event. */
   title: string;
 }
@@ -27,7 +25,7 @@ interface GamblingSectionProps {
  * It handles balance checks, auto-betting options, and displaying existing bets.
  */
 
-const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, userId, title }) => {
+const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, title }) => {
   const [gamblingPoints, setGamblingPoints] = useState<number>(0);
   const [canSubmitGamblingPoints, setCanSubmitGamblingPoints] = useState<boolean>(false);
 
@@ -54,7 +52,6 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, userId, tit
   });
 
   const handleGamblingPointsSubmit = () => {
-    if (!userId) return;
     if (userPoints === undefined) return;
     if (gamblingPoints === undefined || gamblingPoints === null) return;
 
@@ -101,7 +98,6 @@ const GamblingSection: FC<GamblingSectionProps> = ({ gamblingTypeId, userId, tit
             size="sm"
             className="h-8 w-8 p-1"
             onClick={() => {
-              if (!userId) return;
               submitGamblingPoints({
                 gamblingTypeId: gamblingTypeId,
                 points: 0

--- a/src/components/PredictionGame.tsx
+++ b/src/components/PredictionGame.tsx
@@ -510,7 +510,6 @@ const AssignmentPrediction: FC<AssignmentPredictionProps> = ({
           {hasAllGuesses && (
             <AssignmentGamblingBoard
               assignmentId={assignment.id}
-              userId={userId}
               hosts={hosts}
               guesses={guessesForGambling}
               episodeStatus={episodeStatus}

--- a/src/server/api/routers/gamblingRouter.ts
+++ b/src/server/api/routers/gamblingRouter.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { Prisma } from "@prisma/client";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "@/server/api/trpc";
 import { getCurrentSeasonID, calculateUserPoints } from "@/utils/points";
 
@@ -67,7 +68,7 @@ export const gamblingRouter = createTRPCRouter({
 						},
 					});
 				}
-			});
+			}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
 		}),
 	getForAssignment: protectedProcedure
 		.input(z.object({ assignmentId: z.string() }))

--- a/src/server/api/routers/gamblingRouter.ts
+++ b/src/server/api/routers/gamblingRouter.ts
@@ -38,6 +38,8 @@ export const gamblingRouter = createTRPCRouter({
 				if (!defaultType) throw new Error("No active gambling type found");
 				gamblingTypeId = defaultType.id;
 			}
+			const assignmentId = input.assignmentId ?? null;
+			const targetUserId = input.targetUserId ?? null;
 
 			// Perform everything inside a transaction to prevent race conditions on balance verification
 			return await ctx.db.$transaction(async (tx) => {
@@ -46,8 +48,8 @@ export const gamblingRouter = createTRPCRouter({
 						userId: callerId,
 						seasonId: seasonId,
 						gamblingTypeId,
-						assignmentId: input.assignmentId,
-						targetUserId: input.targetUserId,
+						assignmentId,
+						targetUserId,
 					},
 				});
 
@@ -72,8 +74,8 @@ export const gamblingRouter = createTRPCRouter({
 							userId: callerId,
 							gamblingTypeId,
 							points: input.points,
-							assignmentId: input.assignmentId,
-							targetUserId: input.targetUserId,
+							assignmentId,
+							targetUserId,
 						},
 					});
 				}

--- a/src/server/api/routers/gamblingRouter.ts
+++ b/src/server/api/routers/gamblingRouter.ts
@@ -10,13 +10,17 @@ export const gamblingRouter = createTRPCRouter({
 	}),
 	submitPoints: protectedProcedure
 		.input(z.object({
-			userId: z.string(),
 			gamblingTypeId: z.string().optional(),
 			points: z.number(),
 			assignmentId: z.string().optional(),
 			targetUserId: z.string().optional(),
 		}))
 		.mutation(async ({ ctx, input }) => {
+			if (input.points < 0) {
+				throw new Error("Bet amount must be non-negative");
+			}
+
+			const callerId = ctx.session.user.id;
 			const seasonId = await getCurrentSeasonID(ctx.db);
 			if (!input.gamblingTypeId) {
 				const defaultType = await ctx.db.gamblingType.findFirst({
@@ -25,41 +29,45 @@ export const gamblingRouter = createTRPCRouter({
 				if (!defaultType) throw new Error("No active gambling type found");
 				input.gamblingTypeId = defaultType.id;
 			}
-			const existingPoints = await ctx.db.gamblingPoints.findFirst({
-				where: {
-					userId: input.userId,
-					gamblingTypeId: input.gamblingTypeId,
-					assignmentId: input.assignmentId,
-					targetUserId: input.targetUserId,
-				},
-			});
 
-			const availablePoints = await calculateUserPoints(ctx.db, ctx.session.user.email, seasonId);
-			const currentBetAmount = existingPoints ? existingPoints.points : 0;
-			if (input.points > availablePoints + currentBetAmount) {
-				throw new Error("Not enough points available to place this bet");
-			}
-
-			if (existingPoints) {
-				if (existingPoints.status !== "pending") {
-					throw new Error("Cannot update a bet that is already locked or resolved");
-				}
-				return ctx.db.gamblingPoints.update({
-					where: { id: existingPoints.id },
-					data: { points: input.points },
-				});
-			} else {
-				return ctx.db.gamblingPoints.create({
-					data: {
-						seasonId,
-						userId: input.userId,
+			// Perform everything inside a transaction to prevent race conditions on balance verification
+			return await ctx.db.$transaction(async (tx) => {
+				const existingPoints = await tx.gamblingPoints.findFirst({
+					where: {
+						userId: callerId,
 						gamblingTypeId: input.gamblingTypeId,
-						points: input.points,
 						assignmentId: input.assignmentId,
 						targetUserId: input.targetUserId,
 					},
 				});
-			}
+
+				const availablePoints = await calculateUserPoints(tx, ctx.session.user.email, seasonId);
+				const currentBetAmount = existingPoints ? existingPoints.points : 0;
+				if (input.points > availablePoints + currentBetAmount) {
+					throw new Error("Not enough points available to place this bet");
+				}
+
+				if (existingPoints) {
+					if (existingPoints.status !== "pending") {
+						throw new Error("Cannot update a bet that is already locked or resolved");
+					}
+					return tx.gamblingPoints.update({
+						where: { id: existingPoints.id },
+						data: { points: input.points },
+					});
+				} else {
+					return tx.gamblingPoints.create({
+						data: {
+							seasonId,
+							userId: callerId,
+							gamblingTypeId: input.gamblingTypeId,
+							points: input.points,
+							assignmentId: input.assignmentId,
+							targetUserId: input.targetUserId,
+						},
+					});
+				}
+			});
 		}),
 	getForAssignment: protectedProcedure
 		.input(z.object({ assignmentId: z.string() }))

--- a/src/server/api/routers/gamblingRouter.ts
+++ b/src/server/api/routers/gamblingRouter.ts
@@ -22,13 +22,21 @@ export const gamblingRouter = createTRPCRouter({
 			}
 
 			const callerId = ctx.session.user.id;
+			const callerEmail = ctx.session.user.email;
+			if (!callerEmail) {
+				throw new Error("User email is required");
+			}
 			const seasonId = await getCurrentSeasonID(ctx.db);
-			if (!input.gamblingTypeId) {
+			if (!seasonId) {
+				throw new Error("No active season");
+			}
+			let gamblingTypeId = input.gamblingTypeId;
+			if (!gamblingTypeId) {
 				const defaultType = await ctx.db.gamblingType.findFirst({
 					where: { lookupId: "default" },
 				});
 				if (!defaultType) throw new Error("No active gambling type found");
-				input.gamblingTypeId = defaultType.id;
+				gamblingTypeId = defaultType.id;
 			}
 
 			// Perform everything inside a transaction to prevent race conditions on balance verification
@@ -37,13 +45,13 @@ export const gamblingRouter = createTRPCRouter({
 					where: {
 						userId: callerId,
 						seasonId: seasonId,
-						gamblingTypeId: input.gamblingTypeId,
+						gamblingTypeId,
 						assignmentId: input.assignmentId,
 						targetUserId: input.targetUserId,
 					},
 				});
 
-				const availablePoints = await calculateUserPoints(tx, ctx.session.user.email, seasonId);
+				const availablePoints = await calculateUserPoints(tx, callerEmail, seasonId);
 				const currentBetAmount = existingPoints ? existingPoints.points : 0;
 				if (input.points > availablePoints + currentBetAmount) {
 					throw new Error("Not enough points available to place this bet");
@@ -62,7 +70,7 @@ export const gamblingRouter = createTRPCRouter({
 						data: {
 							seasonId,
 							userId: callerId,
-							gamblingTypeId: input.gamblingTypeId,
+							gamblingTypeId,
 							points: input.points,
 							assignmentId: input.assignmentId,
 							targetUserId: input.targetUserId,

--- a/src/server/api/routers/gamblingRouter.ts
+++ b/src/server/api/routers/gamblingRouter.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "@/server/api/trpc";
-import { getCurrentSeasonID } from "@/utils/points";
+import { getCurrentSeasonID, calculateUserPoints } from "@/utils/points";
 
 export const gamblingRouter = createTRPCRouter({
 	getAllActive: publicProcedure.query(({ ctx }) => {
@@ -33,6 +33,12 @@ export const gamblingRouter = createTRPCRouter({
 					targetUserId: input.targetUserId,
 				},
 			});
+
+			const availablePoints = await calculateUserPoints(ctx.db, ctx.session.user.email, seasonId);
+			const currentBetAmount = existingPoints ? existingPoints.points : 0;
+			if (input.points > availablePoints + currentBetAmount) {
+				throw new Error("Not enough points available to place this bet");
+			}
 
 			if (existingPoints) {
 				if (existingPoints.status !== "pending") {

--- a/src/server/api/routers/gamblingRouter.ts
+++ b/src/server/api/routers/gamblingRouter.ts
@@ -36,6 +36,7 @@ export const gamblingRouter = createTRPCRouter({
 				const existingPoints = await tx.gamblingPoints.findFirst({
 					where: {
 						userId: callerId,
+						seasonId: seasonId,
 						gamblingTypeId: input.gamblingTypeId,
 						assignmentId: input.assignmentId,
 						targetUserId: input.targetUserId,


### PR DESCRIPTION
This commit resolves an issue in the Prediction Game where users with 0 points (or insufficient points) could place large bets. It calculates the user's exact balance minus any pending bets before confirming the new bet, stopping any wagers that exceed their actual balance both visually on the client and strictly on the server-side.

---
*PR created automatically by Jules for task [538640140509635166](https://jules.google.com/task/538640140509635166) started by @tonyisup*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bet validation to block non-numeric, non-positive, or over-limit wagers (shows alert).
  * Server now rejects negative point submissions to prevent invalid bets.
  * Bet and Clear/Undo buttons are disabled while user points are unavailable to prevent premature actions.
  * Improved server-side processing for bets to make submissions more reliable and consistent.

* **Chores**
  * Updated .gitignore to ignore a couple of project note files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->