### PR TITLE
feat: make history fuzzy search toggleable

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -25,8 +25,20 @@ function episodeMatchesSubstring(episode: HistoryEpisode, needleLower: string): 
     }
   }
   for (const e of episode.extras) {
-    const t = e.review.movie?.title;
-    if (t !== undefined && t !== null && t.toLowerCase().includes(needleLower)) {
+    const movieTitle = e.review.movie?.title;
+    if (
+      movieTitle !== undefined &&
+      movieTitle !== null &&
+      movieTitle.toLowerCase().includes(needleLower)
+    ) {
+      return true;
+    }
+    const showTitle = e.review.show?.title;
+    if (
+      showTitle !== undefined &&
+      showTitle !== null &&
+      showTitle.toLowerCase().includes(needleLower)
+    ) {
       return true;
     }
   }
@@ -102,7 +114,12 @@ export default function HistoryPage() {
   const fuse = useMemo(() => {
     if (!allEpisodes) return null;
     return new Fuse(allEpisodes, {
-      keys: ["title", "assignments.movie.title", "extras.review.movie.title"],
+      keys: [
+        "title",
+        "assignments.movie.title",
+        "extras.review.movie.title",
+        "extras.review.show.title",
+      ],
       threshold: 0.4,
       ignoreLocation: true,
     });

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -10,6 +10,29 @@ import Fuse from 'fuse.js';
 import { debounce } from 'lodash';
 import { type RouterOutputs } from "@/utils/trpc";
 
+const FUZZY_SEARCH_STORAGE_KEY = "bbpc-history-fuzzy-search";
+
+type HistoryEpisode = RouterOutputs["episode"]["history"][number];
+
+function episodeMatchesSubstring(episode: HistoryEpisode, needleLower: string): boolean {
+  if (episode.title.toLowerCase().includes(needleLower)) {
+    return true;
+  }
+  for (const a of episode.assignments) {
+    const t = a.movie?.title;
+    if (t !== undefined && t !== null && t.toLowerCase().includes(needleLower)) {
+      return true;
+    }
+  }
+  for (const e of episode.extras) {
+    const t = e.review.movie?.title;
+    if (t !== undefined && t !== null && t.toLowerCase().includes(needleLower)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function SearchResults({
   episodes,
   query,
@@ -48,6 +71,26 @@ export default function HistoryPage() {
 
   // Initialize local query state from URL to allow immediate UI updates
   const [query, setQuery] = useState(searchParams.get('q') ?? '');
+  const [fuzzySearch, setFuzzySearch] = useState(true);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(FUZZY_SEARCH_STORAGE_KEY);
+      if (stored === "true") setFuzzySearch(true);
+      else if (stored === "false") setFuzzySearch(false);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const handleFuzzySearchChange = (enabled: boolean) => {
+    setFuzzySearch(enabled);
+    try {
+      localStorage.setItem(FUZZY_SEARCH_STORAGE_KEY, enabled ? "true" : "false");
+    } catch {
+      // ignore
+    }
+  };
 
   // Fetch all episodes for client-side fuzzy search
   const { data: allEpisodes, isLoading } = api.episode.history.useQuery(undefined, {
@@ -59,7 +102,7 @@ export default function HistoryPage() {
   const fuse = useMemo(() => {
     if (!allEpisodes) return null;
     return new Fuse(allEpisodes, {
-      keys: ['title', 'assignments.movie.title'],
+      keys: ["title", "assignments.movie.title", "extras.review.movie.title"],
       threshold: 0.4,
       ignoreLocation: true,
     });
@@ -71,10 +114,14 @@ export default function HistoryPage() {
     const trimmed = query.trim();
     if (!trimmed) return [];
 
-    if (!fuse) return [];
+    if (fuzzySearch) {
+      if (!fuse) return [];
+      return fuse.search(trimmed).map((result) => result.item);
+    }
 
-    return fuse.search(trimmed).map(result => result.item);
-  }, [allEpisodes, query, fuse]);
+    const needle = trimmed.toLowerCase();
+    return allEpisodes.filter((ep) => episodeMatchesSubstring(ep, needle));
+  }, [allEpisodes, query, fuse, fuzzySearch]);
 
   // Debounced URL updater to prevent browser history spam
   const debouncedUpdateUrl = useMemo(
@@ -115,6 +162,15 @@ export default function HistoryPage() {
         </Link>
       </div>
       <div className="w-full max-w-4xl">
+        <label className="mb-3 flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={fuzzySearch}
+            onChange={(e) => handleFuzzySearchChange(e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+          />
+          <span>Fuzzy search</span>
+        </label>
         <SearchFilter onSearch={handleSearch} initialValue={query} />
       </div>
       <ul className="w-full max-w-4xl">

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -150,6 +150,8 @@ export default function HistoryPage() {
     debouncedUpdateUrl(newQuery, searchParams.toString());
   };
 
+  const trimmedQuery = query.trim();
+
   return (
     <div className="container flex flex-col items-center justify-center gap-12 px-4 py-16">
       <div className="flex justify-between items-center w-full max-w-4xl">
@@ -171,12 +173,21 @@ export default function HistoryPage() {
           />
           <span>Fuzzy search</span>
         </label>
-        <SearchFilter onSearch={handleSearch} initialValue={query} />
+        <div className="mb-6 space-y-2">
+          <SearchFilter onSearch={handleSearch} initialValue={query} />
+          {trimmedQuery ? (
+            <p className="text-sm text-gray-600" aria-live="polite">
+              {isLoading
+                ? "Searching…"
+                : `${filteredEpisodes.length} ${filteredEpisodes.length === 1 ? "result" : "results"}`}
+            </p>
+          ) : null}
+        </div>
       </div>
       <ul className="w-full max-w-4xl">
         <SearchResults
           episodes={filteredEpisodes}
-          query={query.trim()}
+          query={trimmedQuery}
           isLoading={isLoading}
         />
       </ul>

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -6,13 +6,18 @@ import { Episode } from "@/components/Episode";
 import SearchFilter from "@/components/common/SearchFilter";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import Fuse from 'fuse.js';
+import Fuse, { type FuseResultMatch } from "fuse.js";
 import { debounce } from 'lodash';
 import { type RouterOutputs } from "@/utils/trpc";
 
 const FUZZY_SEARCH_STORAGE_KEY = "bbpc-history-fuzzy-search";
 
 type HistoryEpisode = RouterOutputs["episode"]["history"][number];
+
+type HistorySearchRow = {
+  episode: HistoryEpisode;
+  fuseMatches?: ReadonlyArray<FuseResultMatch>;
+};
 
 function episodeMatchesSubstring(episode: HistoryEpisode, needleLower: string): boolean {
   if (episode.title.toLowerCase().includes(needleLower)) {
@@ -46,13 +51,13 @@ function episodeMatchesSubstring(episode: HistoryEpisode, needleLower: string): 
 }
 
 function SearchResults({
-  episodes,
+  rows,
   query,
-  isLoading
+  isLoading,
 }: {
-  episodes: RouterOutputs['episode']['history'],
-  query: string,
-  isLoading: boolean
+  rows: HistorySearchRow[];
+  query: string;
+  isLoading: boolean;
 }) {
   if (isLoading) {
     return <p className="text-center">Loading...</p>;
@@ -62,15 +67,20 @@ function SearchResults({
     return <p className="text-center text-gray-400">Enter a search term to find episodes.</p>;
   }
 
-  if (episodes.length === 0) {
+  if (rows.length === 0) {
     return <p className="text-gray-400">No episodes found matching your search.</p>;
   }
 
   return (
     <>
-      {episodes.map((episode) => (
+      {rows.map(({ episode, fuseMatches }) => (
         <li className="mb-8" key={episode.id}>
-          <Episode episode={episode} showMovieTitles={true} searchQuery={query} />
+          <Episode
+            episode={episode}
+            showMovieTitles={true}
+            searchQuery={query}
+            fuseMatches={fuseMatches}
+          />
         </li>
       ))}
     </>
@@ -122,22 +132,28 @@ export default function HistoryPage() {
       ],
       threshold: 0.4,
       ignoreLocation: true,
+      includeMatches: true,
     });
   }, [allEpisodes]);
 
   // Compute filtered episodes based on local query
-  const filteredEpisodes = useMemo(() => {
+  const filteredRows = useMemo((): HistorySearchRow[] => {
     if (!allEpisodes) return [];
     const trimmed = query.trim();
     if (!trimmed) return [];
 
     if (fuzzySearch) {
       if (!fuse) return [];
-      return fuse.search(trimmed).map((result) => result.item);
+      return fuse.search(trimmed).map((result) => ({
+        episode: result.item,
+        fuseMatches: result.matches,
+      }));
     }
 
     const needle = trimmed.toLowerCase();
-    return allEpisodes.filter((ep) => episodeMatchesSubstring(ep, needle));
+    return allEpisodes
+      .filter((ep) => episodeMatchesSubstring(ep, needle))
+      .map((episode) => ({ episode }));
   }, [allEpisodes, query, fuse, fuzzySearch]);
 
   // Debounced URL updater to prevent browser history spam
@@ -196,14 +212,14 @@ export default function HistoryPage() {
             <p className="text-sm text-gray-600" aria-live="polite">
               {isLoading
                 ? "Searching…"
-                : `${filteredEpisodes.length} ${filteredEpisodes.length === 1 ? "result" : "results"}`}
+                : `${filteredRows.length} ${filteredRows.length === 1 ? "result" : "results"}`}
             </p>
           ) : null}
         </div>
       </div>
       <ul className="w-full max-w-4xl">
         <SearchResults
-          episodes={filteredEpisodes}
+          rows={filteredRows}
           query={trimmedQuery}
           isLoading={isLoading}
         />

--- a/src/components/Assignment.tsx
+++ b/src/components/Assignment.tsx
@@ -1,8 +1,13 @@
 import { type FC } from "react";
+import type { FuseResultMatch } from "fuse.js";
 import HomeworkFlag from "./HomeworkFlag";
 import MovieInlinePreview from "./MovieInlinePreview";
 import UserTag from "./UserTag";
-import { highlightText } from "@/utils/text";
+import {
+  fuseIndicesForField,
+  highlightText,
+  highlightTextByIndices,
+} from "@/utils/text";
 import type { Assignment as AssignmentType, Movie, User } from "@prisma/client";
 
 interface AssignmentProps {
@@ -12,12 +17,42 @@ interface AssignmentProps {
   }
   showMovieTitles?: boolean,
   searchQuery?: string,
+  fuseMatches?: ReadonlyArray<FuseResultMatch>;
+  assignmentRefIndex?: number;
 }
 
-const Assignment: FC<AssignmentProps> = ({ assignment, showMovieTitles = false, searchQuery = "" }) => {
+const Assignment: FC<AssignmentProps> = ({
+  assignment,
+  showMovieTitles = false,
+  searchQuery = "",
+  fuseMatches,
+  assignmentRefIndex = -1,
+}) => {
+  const titleIdx =
+    assignmentRefIndex >= 0
+      ? fuseIndicesForField(
+          fuseMatches,
+          "assignments.movie.title",
+          assignmentRefIndex
+        )
+      : [];
+
   return <div className="flex flex-col items-center gap-2 p-2">
-    {assignment.movie && <MovieInlinePreview movie={assignment.movie} />}
-    {showMovieTitles && <div className="text-sm text-gray-500">{highlightText(assignment.movie?.title, searchQuery)} ({assignment.movie?.year})</div>}
+    {assignment.movie && (
+      <MovieInlinePreview
+        movie={assignment.movie}
+        searchQuery={searchQuery}
+        titleHighlightIndices={titleIdx}
+      />
+    )}
+    {showMovieTitles && assignment.movie && (
+      <div className="text-sm text-gray-500">
+        {titleIdx.length > 0
+          ? highlightTextByIndices(assignment.movie.title, titleIdx)
+          : highlightText(assignment.movie.title, searchQuery)}{" "}
+        ({assignment.movie.year})
+      </div>
+    )}
     <div className="flex items-center justify-between gap-4">
       <HomeworkFlag type={assignment.type} />
       <UserTag user={assignment.user} />

--- a/src/components/Episode.tsx
+++ b/src/components/Episode.tsx
@@ -1,4 +1,5 @@
 import { type FC } from "react";
+import type { FuseResultMatch } from "fuse.js";
 import Assignment from "./Assignment";
 import MovieInlinePreview from "./MovieInlinePreview";
 import type {
@@ -12,7 +13,12 @@ import type {
 } from "@prisma/client";
 import Link from "next/link";
 import { AddExtraToNext } from "./AddExtraToNext";
-import { highlightText } from "@/utils/text";
+import {
+  fuseIndicesForField,
+  highlightText,
+  highlightTextByIndices,
+  highlightWithFuseOrQuery,
+} from "@/utils/text";
 import ShowInlinePreview from "./ShowInlinePreview";
 import {
   PredictionGame,
@@ -75,6 +81,8 @@ interface EpisodeProps {
   showMovieTitles?: boolean;
   /** Search query for highlighting relevant text within the episode details. */
   searchQuery?: string;
+  /** When set (e.g. fuzzy search), highlights matched character ranges from Fuse `includeMatches`. */
+  fuseMatches?: ReadonlyArray<FuseResultMatch>;
   /** The complete episode data. */
   episode: CompleteEpisode;
 }
@@ -88,6 +96,7 @@ export const Episode: FC<EpisodeProps> = ({
   allowGuesses: isNextEpisode,
   showMovieTitles = false,
   searchQuery = "",
+  fuseMatches,
 }) => {
   if (!episode) return null;
   const showPredictionGame = isNextEpisode ?? false;
@@ -109,7 +118,12 @@ export const Episode: FC<EpisodeProps> = ({
           </div>
           <div className="flex flex-grow items-center justify-center gap-2 p-2 text-center text-lg leading-tight sm:text-xl md:text-2xl">
             {!episode?.recording &&
-              highlightText(episode?.title ?? "", searchQuery)}
+              highlightWithFuseOrQuery(
+                episode?.title ?? "",
+                searchQuery,
+                fuseMatches,
+                "title"
+              )}
             {episode?.recording && (
               <a
                 className="underline"
@@ -118,7 +132,12 @@ export const Episode: FC<EpisodeProps> = ({
                 target="_blank"
                 rel="noreferrer"
               >
-                {highlightText(episode?.title ?? "", searchQuery)}
+                {highlightWithFuseOrQuery(
+                  episode?.title ?? "",
+                  searchQuery,
+                  fuseMatches,
+                  "title"
+                )}
               </a>
             )}
           </div>
@@ -141,6 +160,7 @@ export const Episode: FC<EpisodeProps> = ({
           assignments={episode.assignments}
           showMovieTitles={showMovieTitles}
           searchQuery={searchQuery}
+          fuseMatches={fuseMatches}
         />
         {showPredictionGame && predictionAssignments.length > 0 && (
           <PredictionGame
@@ -159,6 +179,7 @@ export const Episode: FC<EpisodeProps> = ({
               extras={episode.extras}
               showMovieTitles={showMovieTitles}
               searchQuery={searchQuery}
+              fuseMatches={fuseMatches}
             />
           </>
         )}
@@ -176,6 +197,7 @@ interface EpisodeAssignments {
   showMovieTitles?: boolean;
   assignments: EpisodeAssignment[];
   searchQuery?: string;
+  fuseMatches?: ReadonlyArray<FuseResultMatch>;
 }
 
 /**
@@ -186,6 +208,7 @@ const EpisodeAssignments: FC<EpisodeAssignments> = ({
   assignments,
   showMovieTitles = false,
   searchQuery = "",
+  fuseMatches,
 }) => {
   if (!assignments || assignments.length == 0) return null;
   return (
@@ -199,6 +222,9 @@ const EpisodeAssignments: FC<EpisodeAssignments> = ({
           );
         })
         .map((assignment) => {
+          const assignmentRefIndex = assignments.findIndex(
+            (a) => a.id === assignment.id
+          );
           return (
             <div
               key={assignment.id}
@@ -208,6 +234,8 @@ const EpisodeAssignments: FC<EpisodeAssignments> = ({
                 assignment={assignment}
                 showMovieTitles={showMovieTitles}
                 searchQuery={searchQuery}
+                fuseMatches={fuseMatches}
+                assignmentRefIndex={assignmentRefIndex}
               />
             </div>
           );
@@ -223,6 +251,7 @@ interface EpisodeExtras {
   showMovieTitles?: boolean;
   searchQuery?: string;
   extras: EpisodeExtra[];
+  fuseMatches?: ReadonlyArray<FuseResultMatch>;
 }
 
 /**
@@ -233,17 +262,23 @@ const EpisodeExtras: FC<EpisodeExtras> = ({
   extras,
   showMovieTitles = false,
   searchQuery = "",
+  fuseMatches,
 }) => {
   if (!extras || extras.length == 0) return null;
   return (
     <div className="py-2">
       <div className="flex flex-wrap justify-center gap-2 pb-2">
-        {extras.map((extra) => {
-          const extraTitle = extra.review.movie
-            ? `${extra.review.movie.title} (${extra.review.movie.year})`
-            : extra.review.show
-            ? `${extra.review.show.title} (${extra.review.show.year})`
-            : "";
+        {extras.map((extra, extraIndex) => {
+          const movieTitleIdx = fuseIndicesForField(
+            fuseMatches,
+            "extras.review.movie.title",
+            extraIndex
+          );
+          const showTitleIdx = fuseIndicesForField(
+            fuseMatches,
+            "extras.review.show.title",
+            extraIndex
+          );
 
           return (
             <div
@@ -255,6 +290,7 @@ const EpisodeExtras: FC<EpisodeExtras> = ({
                   <MovieInlinePreview
                     movie={extra.review.movie}
                     searchQuery={searchQuery}
+                    titleHighlightIndices={movieTitleIdx}
                     responsive
                   />
                 )}
@@ -262,12 +298,33 @@ const EpisodeExtras: FC<EpisodeExtras> = ({
                   <ShowInlinePreview
                     show={extra.review.show}
                     searchQuery={searchQuery}
+                    titleHighlightIndices={showTitleIdx}
                     responsive
                   />
                 )}
-                {showMovieTitles && extraTitle && (
+                {showMovieTitles && extra.review.movie && (
                   <div className="text-sm text-gray-500">
-                    {highlightText(extraTitle, searchQuery)}
+                    {movieTitleIdx.length > 0
+                      ? highlightTextByIndices(
+                          extra.review.movie.title,
+                          movieTitleIdx
+                        )
+                      : highlightText(
+                          extra.review.movie.title,
+                          searchQuery
+                        )}{" "}
+                    ({extra.review.movie.year})
+                  </div>
+                )}
+                {showMovieTitles && extra.review.show && !extra.review.movie && (
+                  <div className="text-sm text-gray-500">
+                    {showTitleIdx.length > 0
+                      ? highlightTextByIndices(
+                          extra.review.show.title,
+                          showTitleIdx
+                        )
+                      : highlightText(extra.review.show.title, searchQuery)}{" "}
+                    ({extra.review.show.year})
                   </div>
                 )}
               </div>

--- a/src/components/MovieInlinePreview.tsx
+++ b/src/components/MovieInlinePreview.tsx
@@ -4,18 +4,30 @@ import { type Movie } from "@prisma/client";
 import Image from "next/image";
 import Link from "next/link";
 import type { FC } from "react";
-import { highlightText } from "@/utils/text";
+import { highlightText, highlightTextByIndices } from "@/utils/text";
 import { cn } from "@/lib/utils";
 
 interface MovieInlinePreviewProps {
   movie: Movie;
   searchQuery?: string;
+  /** When set (e.g. fuzzy search), highlights Fuse match ranges on the title. */
+  titleHighlightIndices?: ReadonlyArray<readonly [number, number]>;
   className?: string; // Applied to container (Link)
   imageClassName?: string; // Applied to Image
   responsive?: boolean;
 }
 
-const MovieInlinePreview: FC<MovieInlinePreviewProps> = ({ movie, searchQuery = "", className = "", imageClassName = "", responsive = false }) => {
+const MovieInlinePreview: FC<MovieInlinePreviewProps> = ({
+  movie,
+  searchQuery = "",
+  titleHighlightIndices,
+  className = "",
+  imageClassName = "",
+  responsive = false,
+}) => {
+  const showTitle =
+    Boolean(searchQuery) ||
+    (titleHighlightIndices !== undefined && titleHighlightIndices.length > 0);
   return (
     <Link
       href={movie.url}
@@ -38,9 +50,13 @@ const MovieInlinePreview: FC<MovieInlinePreviewProps> = ({ movie, searchQuery = 
           sizes="(max-width: 640px) 48px, 144px"
         />
       )}
-      {searchQuery && <div className="text-sm">
-        {highlightText(movie.title, searchQuery)}
-      </div>}
+      {showTitle && (
+        <div className="text-sm">
+          {titleHighlightIndices && titleHighlightIndices.length > 0
+            ? highlightTextByIndices(movie.title, titleHighlightIndices)
+            : highlightText(movie.title, searchQuery)}
+        </div>
+      )}
     </Link>
   );
 }

--- a/src/components/ShowInlinePreview.tsx
+++ b/src/components/ShowInlinePreview.tsx
@@ -4,18 +4,29 @@ import { type Show } from "@prisma/client";
 import Image from "next/image";
 import Link from "next/link";
 import type { FC } from "react";
-import { highlightText } from "@/utils/text";
+import { highlightText, highlightTextByIndices } from "@/utils/text";
 import { cn } from "@/lib/utils";
 
 interface ShowInlinePreviewProps {
   show: Show;
   searchQuery?: string;
+  titleHighlightIndices?: ReadonlyArray<readonly [number, number]>;
   className?: string; // Applied to container (Link)
   imageClassName?: string; // Applied to Image
   responsive?: boolean;
 }
 
-const ShowInlinePreview: FC<ShowInlinePreviewProps> = ({ show, searchQuery = "", className = "", imageClassName = "", responsive = false }) => {
+const ShowInlinePreview: FC<ShowInlinePreviewProps> = ({
+  show,
+  searchQuery = "",
+  titleHighlightIndices,
+  className = "",
+  imageClassName = "",
+  responsive = false,
+}) => {
+  const showTitle =
+    Boolean(searchQuery) ||
+    (titleHighlightIndices !== undefined && titleHighlightIndices.length > 0);
   return (
     <Link
       href={show.url}
@@ -38,9 +49,13 @@ const ShowInlinePreview: FC<ShowInlinePreviewProps> = ({ show, searchQuery = "",
           sizes="(max-width: 640px) 48px, 144px"
         />
       )}
-      {searchQuery && <div className="text-sm">
-        {highlightText(show.title, searchQuery)}
-      </div>}
+      {showTitle && (
+        <div className="text-sm">
+          {titleHighlightIndices && titleHighlightIndices.length > 0
+            ? highlightTextByIndices(show.title, titleHighlightIndices)
+            : highlightText(show.title, searchQuery)}
+        </div>
+      )}
     </Link>
   );
 }

--- a/src/components/common/SearchFilter.tsx
+++ b/src/components/common/SearchFilter.tsx
@@ -20,7 +20,7 @@ const SearchFilter = ({
   };
 
   return (
-    <div className="mb-6">
+    <div>
       <form onSubmit={handleSearch} className="flex items-center">
         <input
           type="text"

--- a/src/server/api/routers/episodeRouter.ts
+++ b/src/server/api/routers/episodeRouter.ts
@@ -121,6 +121,7 @@ export const episodeRouter = createTRPCRouter({
 							include: {
 								user: true,
 								movie: true,
+								show: true,
 							},
 						},
 					},

--- a/src/utils/text.tsx
+++ b/src/utils/text.tsx
@@ -1,4 +1,72 @@
-import React, { type ReactElement } from 'react';
+import React, { type ReactElement } from "react";
+import type { FuseResultMatch } from "fuse.js";
+
+function mergeInclusiveRanges(
+  ranges: readonly (readonly [number, number])[]
+): [number, number][] {
+  if (ranges.length === 0) return [];
+  const sorted = [...ranges].map(
+    (r) => [r[0], r[1]] as [number, number]
+  ).sort((a, b) => a[0] - b[0]);
+  const out: [number, number][] = [[sorted[0][0], sorted[0][1]]];
+  for (let i = 1; i < sorted.length; i++) {
+    const [s, e] = sorted[i];
+    const last = out[out.length - 1];
+    if (s <= last[1] + 1) {
+      last[1] = Math.max(last[1], e);
+    } else {
+      out.push([s, e]);
+    }
+  }
+  return out;
+}
+
+/** Character ranges from Fuse `includeMatches` (inclusive start and end). */
+export function highlightTextByIndices(
+  text: string | undefined,
+  indices: ReadonlyArray<readonly [number, number]>
+): ReactElement {
+  if (!text) return <></>;
+  if (indices.length === 0) return <>{text}</>;
+
+  const merged = mergeInclusiveRanges(indices);
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+  merged.forEach(([start, end], i) => {
+    if (start > cursor) {
+      parts.push(text.slice(cursor, start));
+    }
+    parts.push(
+      <mark key={`m-${i}-${start}-${end}`} className="bg-yellow-200">
+        {text.slice(start, end + 1)}
+      </mark>
+    );
+    cursor = end + 1;
+  });
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+  return <>{parts}</>;
+}
+
+export function fuseIndicesForField(
+  fuseMatches: ReadonlyArray<FuseResultMatch> | undefined,
+  key: string,
+  refIndex?: number
+): [number, number][] {
+  if (!fuseMatches?.length) return [];
+  const ranges: [number, number][] = [];
+  for (const m of fuseMatches) {
+    if (m.key !== key) continue;
+    if (refIndex === undefined) {
+      if (m.refIndex !== undefined) continue;
+    } else if (m.refIndex !== refIndex) continue;
+    for (const pair of m.indices) {
+      ranges.push([pair[0], pair[1]]);
+    }
+  }
+  return ranges;
+}
 
 export function highlightText(text: string | undefined, query: string): ReactElement {
   if (!text) return <></>;
@@ -17,4 +85,18 @@ export function highlightText(text: string | undefined, query: string): ReactEle
       )}
     </>
   );
-} 
+}
+
+export function highlightWithFuseOrQuery(
+  text: string | undefined,
+  query: string,
+  fuseMatches: ReadonlyArray<FuseResultMatch> | undefined,
+  fuseKey: string,
+  fuseRefIndex?: number
+): ReactElement {
+  const idx = fuseIndicesForField(fuseMatches, fuseKey, fuseRefIndex);
+  if (idx.length > 0) {
+    return highlightTextByIndices(text, idx);
+  }
+  return highlightText(text, query);
+}

--- a/src/utils/text.tsx
+++ b/src/utils/text.tsx
@@ -1,6 +1,11 @@
 import React, { type ReactElement } from "react";
 import type { FuseResultMatch } from "fuse.js";
 
+/** Escape a string for safe use as a literal segment inside a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
 function mergeInclusiveRanges(
   ranges: readonly (readonly [number, number])[]
 ): [number, number][] {
@@ -71,8 +76,10 @@ export function fuseIndicesForField(
 export function highlightText(text: string | undefined, query: string): ReactElement {
   if (!text) return <></>;
   if (!query) return <>{text}</>;
-  
-  const parts = text.split(new RegExp(`(${query})`, 'gi'));
+
+  const parts = text.split(
+    new RegExp(`(${escapeRegExp(query)})`, "gi")
+  );
   
   return (
     <>


### PR DESCRIPTION
Added a toggle to the History Search page to allow users to switch between fuzzy search and a simple substring search. The toggle state is persisted using localStorage. The simple search matches against episode title, assignment movie title, extra review movie title, and extra review show title. Also updated the Fuse keys to search against extra reviews for more complete parity when toggled on.

---
*PR created automatically by Jules for task [7744437211838472386](https://jules.google.com/task/7744437211838472386) started by @tonyisup*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persisted "Fuzzy Search" toggle with live status/count ("Searching…" / N result(s)); fuzzy mode uses approximate matching, otherwise a case-insensitive substring search.
  * Search now matches inside associated movie and show review titles and uses those matches to highlight titles across episodes, assignments, and inline previews.
  * Improved handling of special characters in search queries so highlights behave correctly.

* **Style**
  * Adjusted spacing in the search filter component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->